### PR TITLE
docs: tidy up README and release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -37,9 +37,10 @@ version-resolver:
       - 'performance'
   default: patch
 template: |
+  Love this little Action? [Let me know!](https://github.com/DanielTamkin/DanielTamkin/issues/new?template=Project_comment.md)
+
   ## Changelog
 
-  Love this little Action? [Let me know!](https://github.com/DanielTamkin/DanielTamkin/issues/new?template=Project_comment.md)
 
   **An update from `$PREVIOUS_TAG`**
 
@@ -48,8 +49,7 @@ template: |
 
 
   ### Reporting errors:
-  Does this release break your workflow?
-  [Create an issue](https://github.com/DanielTamkin/HasLabel/issues/new).
+  Does this release break your workflow? [Create an issue](https://github.com/DanielTamkin/HasLabel/issues/new).
   Chances are you aren't the only one running into that issue. It'll help
   others find possible solutions while notifying me (Daniel Tamkin) of any
   problems.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ If a labels exists on a pull_request, do something.
 
 
 
-![Action Downloads](https://badgen.net/github/assets-dl/DanielTamkin/HasLabel)
 ![Github Release Number](https://badgen.net/github/release/DanielTamkin/HasLabel)
 ![Twitter Follow](https://img.shields.io/twitter/follow/CodeHands?style=social)
 


### PR DESCRIPTION
Cleans up the release-drafter template & the README. Additionally adds a nice "real world example" application of HasLabel.